### PR TITLE
Corrections to the implementation of GPBA-A for more than two objectives

### DIFF
--- a/sims-solvers/sims_solvers/FrontGenerators/CoverageGridPoint.py
+++ b/sims-solvers/sims_solvers/FrontGenerators/CoverageGridPoint.py
@@ -26,17 +26,18 @@ class CoverageGridPoint(FrontGeneratorStrategy):
         Implements GPBA-A algorithm with objective rotation as described in the paper:
         'performs a single run for every iteration and for each objective function'
         """
-        # get the best and worst values for each objective
+        # get the best and worst values for each objective. todo consider computing best and worst only for the objective variables, e.g. all except main_obj_index
         yield from self.get_best_worst_values()
         # convert problem to maximization problem
         self.convert_model_to_maximization()
         
-        num_objectives = len(self.solver.model.objectives)
-        
+        # todo in the original paper only one objective is optimized, rotation is tricky, could lead to missing some points
+        # num_objectives = len(self.solver.model.objectives)
         # Run GPBA-A for each objective as the main one (complete objective rotation)
-        for main_obj_index in range(num_objectives):
-            print(f"🎯 GPBA-A: Running iteration {main_obj_index + 1}/{num_objectives} with objective {main_obj_index} as main objective")
-            yield from self.solve_with_main_objective(main_obj_index)
+        # for main_obj_index in range(num_objectives):
+        #     print(f"🎯 GPBA-A: Running iteration {main_obj_index + 1}/{num_objectives} with objective {main_obj_index} as main objective")
+        #     yield from self.solve_with_main_objective(main_obj_index)
+        yield from self.solve_with_main_objective(0)
     
     def solve_with_main_objective(self, main_obj_index):
         """
@@ -71,22 +72,26 @@ class CoverageGridPoint(FrontGeneratorStrategy):
         # Create interval managers for each constraint objective
         ef_intervals = []
         for i in constraint_indices:
-            min_interval = min(self.nadir_objectives_values[i], self.best_objective_values[i])
-            max_interval = max(self.nadir_objectives_values[i], self.best_objective_values[i])
-            ef_intervals.append(IntervalManager(min_interval+1, max_interval-1))
+            ef_intervals.append(self.create_interval(i))
 
-        # Initialize ef_array with middle points for all constraint objectives
+        # Initialize ef_array with the nadir points for all constraint objectives
         for j, i in enumerate(constraint_indices):
-            ef_array[j] = int((self.best_objective_values[i] + self.nadir_objectives_values[i]) / 2)
-        
-        yield from self.coverage_loop(ef_array, previous_solutions, previous_solution_information, ef_intervals, constraint_indices)
+            ef_array[j] = int(self.nadir_objectives_values[i])
 
-    def coverage_loop(self, ef_array, previous_solutions, previous_solution_information, ef_intervals, constraint_indices):
+        # Initialize the relative worst values
+        rwv = [0] * len(constraint_indices)
+        for i in range(len(constraint_indices)):
+            rwv[i] = self.best_objective_values[constraint_indices[i]]
+
+        yield from self.coverage_loop(ef_array, rwv, previous_solutions, previous_solution_information, ef_intervals, constraint_indices)
+
+    def coverage_loop(self, ef_array, rwv, previous_solutions, previous_solution_information, ef_intervals, constraint_indices):
         """
         Main coverage loop for GPBA-A algorithm.
         
         Args:
             ef_array: Array of constraint values
+            rwv: Relative worst values for constraint objectives
             previous_solutions: Set of previous solution strings
             previous_solution_information: List of previous solution information
             ef_intervals: List of interval managers for constraint objectives
@@ -94,33 +99,21 @@ class CoverageGridPoint(FrontGeneratorStrategy):
         """
         # For multi-objective, continue while any constraint objective has valid intervals
         iteration_count = 0
+        # todo the algorithm should finish when all the points are found, max_iterations is only useful if you want to use them as a stopping condition
         max_iterations = 1000  # Safety limit to prevent infinite loops
         
-        while (any(len(interval.intervals) > 0 for interval in ef_intervals) and 
-               iteration_count < max_iterations):
-            yield from self.coverage_most_inner_loop(ef_array, previous_solutions, previous_solution_information,
+        while ef_array[0] <= self.best_objective_values[constraint_indices[0]]:
+            yield from self.coverage_most_inner_loop(ef_array, rwv, previous_solutions, previous_solution_information,
                                                      ef_intervals, constraint_indices)
             iteration_count += 1
-            
-            # Update ef_array to next valid point from intervals
-            updated = False
-            for i, interval_manager in enumerate(ef_intervals):
-                if len(interval_manager.intervals) > 0:
-                    largest_interval = interval_manager.find_largest_interval()
-                    if largest_interval is not None:
-                        ef_array[i] = int((largest_interval[0] + largest_interval[1]) / 2)
-                        updated = True
-                        break
-            
-            if not updated:
-                break
 
-    def coverage_most_inner_loop(self, ef_array, previous_solutions, previous_solution_information, ef_intervals, constraint_indices):
+    def coverage_most_inner_loop(self, ef_array, rwv, previous_solutions, previous_solution_information, ef_intervals, constraint_indices):
         """
         Inner loop of coverage algorithm that solves each constraint configuration.
         
         Args:
             ef_array: Array of constraint values
+            rwv: Relative worst values for constraint objectives
             previous_solutions: Set of previous solution strings
             previous_solution_information: List of previous solution information
             ef_intervals: List of interval managers for constraint objectives
@@ -173,41 +166,64 @@ class CoverageGridPoint(FrontGeneratorStrategy):
                         calculated_cloud_uncovered = self.solver.model.calculate_cloud_uncovered(formatted_solution["solution_values"])
                         if calculated_cloud_uncovered != abs(one_solution[1]):
                             print(f"Cloud covered error. Expected: {one_solution[1]}, calculated: {calculated_cloud_uncovered}")
-        # Update all constraint objectives
-        for i in range(len(self.constraint_objectives)):
-            self.adjust_parameter_ef_array(gamma, i, ef_array, one_solution, ef_intervals[i], constraint_indices)
+        # Update relative worst values array
+        sol_obj_id = None
+        id_interval = -1
+        if len(one_solution) > 0:
+            for i in range(len(rwv)):
+                rwv[i] = min(rwv[i], one_solution[constraint_indices[i]])
+            sol_obj_id = one_solution[constraint_indices[id_interval]]
 
-    def adjust_parameter_ef_array(self, gamma, id_constraint_objective, ef_array, one_solution, ef_interval, constraint_indices):
+        # Update all constraint objectives. NOTE: An objective x (with 0 < x < p-1, where p-1 is the index of the last objective) is only updated when the ef_array[x-1] > best_value[x-1]
+        ef_intervals[id_interval] = self.adjust_parameter_ef_array(id_interval, ef_array, sol_obj_id, ef_intervals[id_interval], constraint_indices, gamma)
+        for i in range(len(constraint_indices)-1, 0, -1):
+            if ef_array[i] > self.best_objective_values[constraint_indices[i]]:
+                ef_array[i] = self.nadir_objectives_values[constraint_indices[i]]
+                rwv[i] = self.best_objective_values[constraint_indices[i]]
+                id_interval = i - 1
+                if sol_obj_id is not None:
+                    sol_obj_id = one_solution[constraint_indices[id_interval]]
+                ef_intervals[id_interval] = self.adjust_parameter_ef_array(id_interval, ef_array, sol_obj_id,
+                                               ef_intervals[id_interval], constraint_indices, gamma)
+            else:
+                break
+
+    def adjust_parameter_ef_array(self, id_constraint_objective, ef_array, sol_obj_k, ef_interval, constraint_indices, gamma=1):
         """
         Adjust the ef_array parameter based on the solution found.
         
         Args:
-            gamma: Coverage parameter
             id_constraint_objective: Index in the constraint objective array (0-based)
             ef_array: Array of constraint values
-            one_solution: Solution found (or empty if infeasible)
+            sol_obj_k: Objective k value for the solution found (or None if infeasible)
             ef_interval: Interval manager for this constraint objective
             constraint_indices: Indices of objectives that are constraints (not main objective)
+            gamma: Coverage parameter
         """
         # check if the list one_solution is empty
         start_removal = ef_array[id_constraint_objective]
         new_max_interval = start_removal - 1
-        if not one_solution:
+        if sol_obj_k is None:
             end_removal = ef_interval.max_value
         else:
             # Map from constraint objective index to actual objective index
-            actual_obj_index = constraint_indices[id_constraint_objective]
-            end_removal = min(one_solution[actual_obj_index], ef_interval.max_value)
+            end_removal = min(sol_obj_k, ef_interval.max_value)
         ef_interval.remove_interval(start_removal, end_removal)
         # update max_value
         if end_removal >= ef_interval.max_value:
             ef_interval.max_value = new_max_interval
         max_interval = ef_interval.find_largest_interval()
-        if max_interval is not None:
-            ef_array[id_constraint_objective] = int((max_interval[0] + max_interval[1]) / 2)
+        actual_obj_index = constraint_indices[id_constraint_objective]
+        if ef_array[id_constraint_objective] == self.nadir_objectives_values[actual_obj_index]:
+            ef_array[id_constraint_objective] = self.best_objective_values[actual_obj_index]
         else:
-            actual_obj_index = constraint_indices[id_constraint_objective]
-            ef_array[id_constraint_objective] = self.best_objective_values[actual_obj_index] + 1
+            if max_interval is not None:
+                ef_array[id_constraint_objective] = int((max_interval[0] + max_interval[1]) / 2)
+            else:
+                ef_array[id_constraint_objective] = self.best_objective_values[actual_obj_index] + 1
+                # reinitialize the interval manager to avoid stopping the algorithm
+                ef_interval = self.create_interval(actual_obj_index)
+        return ef_interval
 
     def convert_model_to_maximization(self):
         if not self.solver.model.is_a_minimization_model():
@@ -234,17 +250,18 @@ class CoverageGridPoint(FrontGeneratorStrategy):
                 self.best_objective_values[i] = int(objective_val)
                 formatted_solutions.append(formatted_solution)
                 self.front_solutions.append(formatted_solution)
-                
-                # For nadir calculation, use the worst values from other objectives when optimizing objective i
-                obj_values = formatted_solution['objs']
-                for j in range(num_objectives):
-                    if i != j:
-                        # Update nadir if this is worse than current nadir for objective j
-                        if self.nadir_objectives_values[j] == 0 or obj_values[j] > self.nadir_objectives_values[j]:
-                            self.nadir_objectives_values[j] = obj_values[j]
             else:
                 raise TimeoutError(f"Timeout while optimizing objective {i}")
-        
+        # Get the nadir values by optimizing each objective in the opposite sense. Do it after getting the best values,
+        # because the best values are potential Pareto points, but the nadir values are not. If the time is short, it is better to get the best values.
+        nadir_optimization_sense = "min" if self.model_optimization_sense == "max" else "max"
+        for i in range(num_objectives):
+            sols, objective_val = self.optimize_single_objectives(nadir_optimization_sense, i)
+            if objective_val is not None:
+                self.nadir_objectives_values[i] = int(objective_val)
+            else:
+                raise TimeoutError(f"Timeout while optimizing objective {i}")
+
         # Yield all found extreme solutions
         for formatted_solution in formatted_solutions:
             if formatted_solution is not None:
@@ -272,6 +289,12 @@ class CoverageGridPoint(FrontGeneratorStrategy):
 
     def always_add_new_solutions_to_front(self):
         return False
+
+    def create_interval(self, i):
+        min_interval = min(self.nadir_objectives_values[i], self.best_objective_values[i])
+        max_interval = max(self.nadir_objectives_values[i], self.best_objective_values[i])
+        # todo Vlad review if it should be min_interval or min_interval+1 and max_interval or max_interval-1
+        return IntervalManager(min_interval + 1, max_interval - 1)
 
 
 class IntervalManager:

--- a/sims-solvers/sims_solvers/Models/GurobiModels/SatelliteImageMosaicSelectionGurobiModel.py
+++ b/sims-solvers/sims_solvers/Models/GurobiModels/SatelliteImageMosaicSelectionGurobiModel.py
@@ -125,7 +125,12 @@ class SatelliteImageMosaicSelectionGurobiModel(GurobiModel, SatelliteImageMosaic
         # Find the index of resolution objective if it exists and calculate it manually
         for i, obj_name in enumerate(objectives_to_use):
             if obj_name == "min_resolution":
+                # todo Vlad please review if this is correct. Sometimes calculate_resolution changed the sign of the value
+                sign = 1 if objective_values[i] >= 0 else -1
                 objective_values[i] = self.calculate_resolution(selected_images)
+                # check if sign changed
+                if (objective_values[i] >= 0 > sign) or (objective_values[i] < 0 < sign):
+                    objective_values[i] *= -1
                 break
             elif obj_name not in ["min_cost", "cloud_coverage", "min_resolution", "min_max_incidence_angle"]:
                 raise ValueError(f"Invalid objective '{obj_name}'. Valid objectives are: min_cost, cloud_coverage, min_resolution, min_max_incidence_angle")

--- a/sims-solvers/sims_solvers/Solvers/GurobiSolver.py
+++ b/sims-solvers/sims_solvers/Solvers/GurobiSolver.py
@@ -95,7 +95,7 @@ class GurobiSolver(Solver):
         
         constraint_objectives = []
         if augmentation:
-            delta = 0.0001  # delta should be between 0.001 and 0.000001
+            delta = 0.01  # delta should be between 0.001 and 0.000001. In the paper of  Mesquita-Cunha et al. 2021 it is set to 0.01 for computational experiments.
             
             # Create slack variables for all constraint objectives (all except main_obj_index)
             slack_vars = []
@@ -105,10 +105,17 @@ class GurobiSolver(Solver):
                 max_s = abs(best_constrain_obj_list[i] - nadir_constrain_obj_list[i])
                 s = self.model.solver_model.addVar(vtype=gp.GRB.INTEGER, lb=0, ub=max_s, name=f"s{i+1}")
                 slack_vars.append(s)
+            # objective ranges
+            obj_range = []
+            for i in constraint_indices:
+                obj_range.append(abs(best_constrain_obj_list[i] - nadir_constrain_obj_list[i]))
             
-            # Main objective: selected objective + delta * sum of slack variables
-            slack_sum = sum(slack_vars) if slack_vars else 0
-            obj = self.model.objectives[main_obj_index] + (delta * slack_sum)
+            # Main objective: selected objective + delta * sum_{k=2,..p}(10^(k-1)*slack[k] / range[k])
+            slack_range_sum = 0
+            for i in range(len(constraint_indices)):
+                slack_range_sum += slack_vars[i]/(10 ** i * obj_range[i])
+
+            obj = self.model.objectives[main_obj_index] + (delta * slack_range_sum)
             self.set_single_objective(obj)
             
             # Constraint objectives: each constraint objective minus its corresponding slack variable

--- a/sims-solvers/sims_solvers/Solvers/MinizincSolver.py
+++ b/sims-solvers/sims_solvers/Solvers/MinizincSolver.py
@@ -55,6 +55,9 @@ class MinizincSolver(Solver):
         print("Deactivating lexicographic optimization is not implemented yet for MinizincSolver.")
         raise NotImplementedError()
 
+    def add_constraints_eq(self, constraint, rhs):
+        raise NotImplementedError()
+
     def add_constraints_leq(self, constraint, rhs):
         raise NotImplementedError()
 

--- a/sims-solvers/sims_solvers/Solvers/Solver.py
+++ b/sims-solvers/sims_solvers/Solvers/Solver.py
@@ -67,6 +67,10 @@ class Solver(ABC):
             raise ValueError("Invalid optimization sense: " + sense)
 
     @abstractmethod
+    def add_constraints_eq(self, constraint, rhs):
+        pass
+
+    @abstractmethod
     def add_constraints_leq(self, constraint, rhs):
         pass
 


### PR DESCRIPTION
Corrections to the implementation of GPBA-A

1- Choose which objective is designated as main_obj_index before the algorithm starts. In the paper, this objective does not change. Changing it at runtime is non-trivial; if we do, it will be a contribution and we need to think about how to do it.
2- Start from the nadir for all objectives (like in the original paper), not the midpoint. Find the best point second, and then the midpoint.
3- Use a list with the relative worst values (rwv). This is used for more than 2 objectives (not implemented in the first version).
4- Fix the stopping criterion: stop when objective 2 exceeds its optimum. The number of iterations could be used as an alternative to the running time, but it is not needed to prevent infinite runs.
5- Fix how ef_array is updated: update the last element (innermost loop) each time a solution is found. Update the others only when the inner element exceeds the corresponding optimum value.
6- Fix the implementation of adjust_parameter_ef_array.
7- Fix how nadir points are computed for each objective.
8- Fix the objective function for more than two objectives.