### PR TITLE
Fix: Gurobi MILP solver doesn't discover all solutions, despite setting "exhastive": "true" flag

### DIFF
--- a/sims-solvers/sims_solvers/FrontGenerators/CoverageGridPoint.py
+++ b/sims-solvers/sims_solvers/FrontGenerators/CoverageGridPoint.py
@@ -17,6 +17,7 @@ class CoverageGridPoint(FrontGeneratorStrategy):
         self.constraint_objectives = [0] * (len(self.solver.model.objectives) - 1)
         self.is_a_minimization_model_originally = False
         self.logger = logging.getLogger(__name__)
+        self.obj_k_at_ef_k = [None] * (len(self.solver.model.objectives) - 1)
 
     def set_multiply_solution_by_minus_one(self):
         if self.model_optimization_sense == "min":
@@ -178,24 +179,28 @@ class CoverageGridPoint(FrontGeneratorStrategy):
                         if calculated_cloud_uncovered != abs(one_solution[1]):
                             print(f"Cloud covered error. Expected: {one_solution[1]}, calculated: {calculated_cloud_uncovered}")
         # Update relative worst values array
-        sol_obj_id = None
         id_interval = -1
+        self.obj_k_at_ef_k[id_interval] = None
         if len(one_solution) > 0:
             for i in range(len(rwv)):
                 rwv[i] = min(rwv[i], one_solution[constraint_indices[i]])
-            sol_obj_id = one_solution[constraint_indices[id_interval]]
+                self.obj_k_at_ef_k[i] = rwv[i]
+            self.obj_k_at_ef_k[id_interval] = one_solution[constraint_indices[id_interval]]
 
-        # Update all constraint objectives. NOTE: An objective x (with 0 < x < p-1, where p-1 is the index of the last objective) is only updated when the ef_array[x-1] > best_value[x-1]
-        ef_intervals[id_interval] = self.adjust_parameter_ef_array(id_interval, ef_array, sol_obj_id, ef_intervals[id_interval], constraint_indices, gamma)
+        # Update all constraint objectives. NOTE: An objective x (with 1 <= x <= p-2, where p-1 is the index of the
+        # last objective) is only updated when the ef_array[x+1] > best_value[x+1]
+        ef_intervals[id_interval] = self.adjust_parameter_ef_array(id_interval, ef_array, self.obj_k_at_ef_k[id_interval], ef_intervals[id_interval], constraint_indices, gamma)
         for i in range(len(constraint_indices)-1, 0, -1):
             if ef_array[i] > self.best_objective_values[constraint_indices[i]]:
                 ef_array[i] = self.nadir_objectives_values[constraint_indices[i]]
                 rwv[i] = self.best_objective_values[constraint_indices[i]]
                 id_interval = i - 1
-                if sol_obj_id is not None:
-                    sol_obj_id = one_solution[constraint_indices[id_interval]]
-                ef_intervals[id_interval] = self.adjust_parameter_ef_array(id_interval, ef_array, sol_obj_id,
-                                               ef_intervals[id_interval], constraint_indices, gamma)
+                ef_intervals[id_interval] = self.adjust_parameter_ef_array(id_interval, ef_array, self.obj_k_at_ef_k[id_interval],
+                                                                           ef_intervals[id_interval], constraint_indices, gamma)
+                self.obj_k_at_ef_k[id_interval] = None
+                # todo review this part, it is not in the original algorithm but I think it is correct and speed up the resolution time
+                if i == 1:
+                    rwv[id_interval] = self.best_objective_values[constraint_indices[id_interval]]
             else:
                 break
 
@@ -219,7 +224,12 @@ class CoverageGridPoint(FrontGeneratorStrategy):
         else:
             # Map from constraint objective index to actual objective index
             end_removal = min(sol_obj_k, ef_interval.max_value)
-        ef_interval.remove_interval(start_removal, end_removal)
+        if start_removal < end_removal:
+            ef_interval.remove_interval(start_removal, end_removal)
+        else:
+            ef_interval.remove_one_point(start_removal)
+            if start_removal > end_removal:
+                ef_interval.remove_one_point(end_removal)
         # update max_value
         if end_removal >= ef_interval.max_value:
             ef_interval.max_value = new_max_interval
@@ -230,10 +240,10 @@ class CoverageGridPoint(FrontGeneratorStrategy):
         else:
             if max_interval is not None:
                 ef_array[id_constraint_objective] = int((max_interval[0] + max_interval[1]) / 2)
-            else:
-                ef_array[id_constraint_objective] = self.best_objective_values[actual_obj_index] + 1
-                # reinitialize the interval manager to avoid stopping the algorithm
-                ef_interval = self.create_interval(actual_obj_index)
+        else:
+            ef_array[id_constraint_objective] = self.best_objective_values[actual_obj_index] + 1
+            # reinitialize the interval manager to avoid stopping the algorithm
+            ef_interval = self.create_interval(actual_obj_index)
         return ef_interval
 
     def convert_model_to_maximization(self):
@@ -305,7 +315,7 @@ class CoverageGridPoint(FrontGeneratorStrategy):
         min_interval = min(self.nadir_objectives_values[i], self.best_objective_values[i])
         max_interval = max(self.nadir_objectives_values[i], self.best_objective_values[i])
         # todo Vlad review if it should be min_interval or min_interval+1 and max_interval or max_interval-1
-        return IntervalManager(min_interval + 1, max_interval - 1)
+        return IntervalManager(min_interval, max_interval)
 
 
 class IntervalManager:
@@ -328,6 +338,18 @@ class IntervalManager:
                 to_add = (min(to_add[0], interval[0]), max(to_add[1], interval[1]))
         new_intervals.add(to_add)
         self.intervals = new_intervals
+
+    def remove_one_point(self, point):
+        new_intervals = set()
+        for interval in self.intervals:
+            if interval[0] <= point <= interval[1]:  # Point is within this interval
+                if interval[0] < point:
+                    new_intervals.add((interval[0], point - 1))
+                if interval[1] > point:
+                    new_intervals.add((point + 1, interval[1]))
+            else:  # No overlap, keep interval
+                new_intervals.add(interval)
+        self.intervals = new_intervals  # Update intervals
 
     def remove_interval(self, start, end):
         """

--- a/sims-solvers/sims_solvers/Models/SatelliteImageMosaicSelectionGeneralModel.py
+++ b/sims-solvers/sims_solvers/Models/SatelliteImageMosaicSelectionGeneralModel.py
@@ -96,6 +96,7 @@ class SatelliteImageMosaicSelectionGeneralModel(GenericModel, ABC):
         return float(sum(resolution_parts_max.values()))
 
     def assert_solution(self, solution: list[float], selected_images: list[int]) -> None:
+        # todo only assert the objectives that are in the problem
         self.assert_is_a_cover(selected_images)
         self.assert_cost(selected_images, solution[0])
         self.assert_cloud_covered(selected_images, solution[1])

--- a/sims-solvers/tests/test_unit_4objectives.py
+++ b/sims-solvers/tests/test_unit_4objectives.py
@@ -146,8 +146,15 @@ class TestIntervalManager:
         manager.remove_interval(3, 5)
         largest = manager.find_largest_interval()
         assert largest is not None, "Should find largest interval after removal"
+        assert largest[0] == 6 and largest[1] == 10, "Largest interval should be [1,2]"
+
+        # Test point removal
+        manager.remove_one_point(7)
+        for interval in manager.intervals:
+            assert 7 < interval[0] or 7 > interval[1], "Point 7 should be removed from intervals"
         
         # Test interval addition
+        manager = IntervalManager(1, 10)
         manager.add_interval(15, 20)
         assert len(manager.intervals) >= 1, "Should have intervals after addition"
 


### PR DESCRIPTION
Fix bug in interval removal for objectives 1..p-2: starting point was taken from the last solution value; it must use the worst relative value `wv_k` from the previous iteration:
- For objective k, an “iteration” ends after fully exploring objective k+1 and resetting it to `nadir_{k+1}`.
- If the last iteration produced no solution, remove the full range `[ef_k, best_k]` for objective k.
- Note: this was ambiguous in the paper and contributed to the bug.

Update policy for `wv_k`:
- Keep the solution-based update: `wv_k = min(wv_k, obj_k(sol))`.
- Also update `wv_k` at the end of each iteration (when objective k+1 is reset), not only when `ef_k` is set back to `nadir_k`.

Refs #3
